### PR TITLE
json2js: キャラシサイトの仕様変更に伴う取得元アドレスの変更

### DIFF
--- a/lib/d1lcs/element.rb
+++ b/lib/d1lcs/element.rb
@@ -10,7 +10,7 @@ module D1lcs
     # 1キャラシ(1行)を作成する各要素を用意するためのクラス
     
     # オンラインキャラクターシートのJSON出力用URL
-    CHARA_SHEET_URL = 'http://detatoko-saga.com/character/%d.json'
+    CHARA_SHEET_URL = 'http://detatoko-saga.com/character/%d.js'
 
     # エラーが発生した時
     attr_reader :error

--- a/lib/d1lcs/version.rb
+++ b/lib/d1lcs/version.rb
@@ -1,4 +1,4 @@
 module D1lcs
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
   USER_AGENT = "Ruby/#{RUBY_VERSION} (#{RUBY_DESCRIPTION}) d1lcs-gem/#{VERSION}"
 end


### PR DESCRIPTION
[キャラクターシート共有サイト](http://detatoko-saga.com/character/) の仕様変更に伴い、JSON出力ページに 404 エラーが出るようになっていた。
アクセス出来るよう、出力ページの URL を書き換えた。